### PR TITLE
bake the git rev to a file in the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+git-rev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
   include:
     - stage: test
       script:
+        - rm -f git-rev && git rev-parse --short HEAD | tr -d '\n' > git-rev
         - npm install
         - npm test
     - stage: build docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,26 @@
 FROM node:12 as base
 
 WORKDIR '/usr/app'
+
+COPY package*.json index.js server.js git-rev ./
 RUN npm set progress=false && npm config set depth 0
 
 #
-# ---- Install and Test ----
+# ---- Test ----
 FROM base as test
 
-COPY package*.json ./
+COPY . ./
+
 # Install all modules including dev dependancies
 RUN npm install
-COPY . ./
 RUN npm run lint && npm run test
 
 #
 # ---- Release ----
 FROM base AS release
 
-COPY package*.json ./
 # copy production node_modules
 RUN npm install --only=production
-# copy app sources
-COPY . ./
 
 EXPOSE 8000
 ENTRYPOINT ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,13 @@ help: ## This help.
 # DOCKER TASKS
 # Build the container
 build: ## Build the container
+	rm -f git-rev
+	git rev-parse --short HEAD | tr -d '\n' > git-rev
 	docker build -t $(APP_NAME) .
 
 build-nc: ## Build the container without caching
+	rm -f git-rev
+	git rev-parse --short HEAD | tr -d '\n' > git-rev
 	docker build --no-cache -t $(APP_NAME) .
 
 run: ## Run container on port configured in `config.env`
@@ -40,7 +44,9 @@ run: ## Run container on port configured in `config.env`
 stop: ## Stop and remove a running container
 	docker stop $(APP_NAME); docker rm $(APP_NAME)
 
-tests: ## Run npm test suite manually
+tests: ## Run npm test suite
+	rm -f git-rev
+	git rev-parse --short HEAD | tr -d '\n' > git-rev
 	npm test
 
 release: build-nc publish ## Make a release by building and publishing the `{version}` ans `latest` tagged containers to the container repo

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimal API built with Express JS and run with Docker that exposes a HTTP API 
 # Background Information:
 
 - I'm coming from a Platform Operations and Automation (Puppet) background to Platform Engineering.
-- This is testing web development skills and as such is not in my area of expertise.
+- A portion of this exercise tested web development skills and as such is not in my area of expertise.
 - As requested I've written the application in Javascript, however this is my first attempt with the language and with web development.
 
 ---
@@ -28,7 +28,7 @@ Sending a GET request to http://localhost:8000/version should return similar to 
 ```json
 "myapplication": [
   {
-    "version": "1.0",
+    "version": "1.0.0",
     "lastcommitsha": "abc57858585",
     "description" : "pre-interview technical test"
   } ]
@@ -43,9 +43,10 @@ Application releases will comply with [Semantic Versioning 2.0.0](https://semver
 The Travis CI build is configured in `.travis.yml`
 
 Travis:
-- Builds the application-in Docker
-- Runs some basic tests
-- Deploys the docker image to [Docker Hub](https://hub.docker.com/repository/docker/sammcj/anz-test-2/)
+- Writes the current git rev SHA (short) to a file that is baked into the image.
+- Builds the application-in Docker.
+- Runs some basic tests.
+- Deploys the docker image to [Docker Hub](https://hub.docker.com/repository/docker/sammcj/anz-test-2/).
 
 If you wish to run builds against your own Travis instance, you'll need to set the `DOCKER_USERNAME` and `DOCKER_PASSWORD` variables in the Travis UI.
 
@@ -86,7 +87,11 @@ make run
 ```
 _Exposes an HTTP API at http://localhost:8000/version_
 
-### Manually Run Tests:
+### Test
+
+- Quality: CodeBeat and DeepScan SaaS running on GitHub against the repo.
+- Security: Whitesource Bolt and DependaBot SaaS running on GitHub against the repo.
+- Functional:
 
 ```
 make tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node_api_example",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple node API example app",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -2,11 +2,13 @@ const express = require("express")
 const packageJSON = require('./package.json');
 
 const app = express()
+var fs = require('fs');
 
 // Get the current git SHA
-revision = require('child_process')
-  .execSync('git rev-parse --short HEAD')
-  .toString().trim()
+revision = fs.readFileSync('git-rev', 'utf8', function(err, data) {
+    if (err) throw err;
+    console.log(data);
+  });
 
 // Return JSON on GET of /version
 app.get('/version', (req, res) => {


### PR DESCRIPTION
- Rather than calling out to exec git, read the git rev from a file backed in to the image during build
- Slightly reduce docker image size